### PR TITLE
Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ The prediction container is expected to read a CSV in the form of `POS,REF,ALT,G
 ```bash
 git clone https://github.com/jodyphelan/tb-ml.git
 pip install .
+pip install git+https://github.com/julibeg/argpass.git
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ The prediction container is expected to read a CSV in the form of `POS,REF,ALT,G
 
 ```bash
 git clone https://github.com/jodyphelan/tb-ml.git
+pip install -r requirements.txt 
 pip install .
-pip install git+https://github.com/julibeg/argpass.git
 ```

--- a/docker/freebayes_VC_pipeline/vcf_header.txt
+++ b/docker/freebayes_VC_pipeline/vcf_header.txt
@@ -2,4 +2,4 @@
 ##reference=/home/jody/refgenome/MTB-h37rv_asm19595v2-eg18.fa
 ##contig=<ID=Chromosome,length=4411532>
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Estimated allele frequency in the range (0,1]">
-#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+#CHROM  POS ID  REF ALT QUAL    FILTER  INFO


### PR DESCRIPTION
Some things noticed while testing

- Needed to install argpass
- The VCF header needed "\t" converted to tabs and a newline on the last line. The first variant was not being genotyped because of the malformed VCF (see below)

The VCF before:
```
##fileformat=VCFv4.2
##reference=/home/jody/refgenome/MTB-h37rv_asm19595v2-eg18.fa
##contig=<ID=Chromosome,length=4411532>
##INFO=<ID=AF,Number=A,Type=Float,Description="Estimated allele frequency in the range (0,1]">
#CHROM  POS ID  REF ALT QUAL    FILTER  INFOChromosome	418	.	C	A	.	.	AF=1
Chromosome	698	.	G	A	.	.	AF=1
```
The VCF after the change:
```
##fileformat=VCFv4.2
##reference=/home/jody/refgenome/MTB-h37rv_asm19595v2-eg18.fa
##contig=<ID=Chromosome,length=4411532>
##INFO=<ID=AF,Number=A,Type=Float,Description="Estimated allele frequency in the range (0,1]">
#CHROM  POS ID  REF ALT QUAL    FILTER  INFO
Chromosome	418	.	C	A	.	.	AF=1
Chromosome	698	.	G	A	.	.	AF=1
```